### PR TITLE
temporarily remove build job

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,16 +9,16 @@ on:
       - release
 
 jobs:
-  build:
-    #if: github.event.base_ref == 'refs/head/release'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - run: npm ci
-      - run: npm test
+#   build:
+#     #if: github.event.base_ref == 'refs/head/release'
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v2
+#       - uses: actions/setup-node@v1
+#         with:
+#           node-version: 12
+#       - run: npm ci
+#       - run: npm test
 
   publish-npm:
     #if: github.event.base_ref == 'refs/head/release'


### PR DESCRIPTION
It's not currently necessary, especially since there is no testing framework setup as of yet.